### PR TITLE
Fix package-lint warnings

### DIFF
--- a/benchmark-init-modes.el
+++ b/benchmark-init-modes.el
@@ -4,7 +4,6 @@
 
 ;; Author: David Holm <dholmster@gmail.com>
 ;; Created: 05 Apr 2014
-;; Keywords: benchmark
 
 ;; This file is not part of GNU Emacs.
 

--- a/benchmark-init.el
+++ b/benchmark-init.el
@@ -1,4 +1,4 @@
-;;; benchmark-init.el --- Benchmarks Emacs require and load calls
+;;; benchmark-init.el --- Benchmarks for require and load calls
 
 ;; Copyright (C) 2013 Steve Purcell
 ;; Copyright (C) 2013-2014 David Holm
@@ -6,7 +6,10 @@
 ;; Author: Steve Purcell
 ;; Maintainer: David Holm <dholmster@gmail.com>
 ;; Created: 25 Apr 2013
-;; Keywords: benchmark
+;; Keywords: convenience benchmark
+;; Version: 1.0.0
+;; URL: https://github.com/dholm/benchmark-init-el
+;; Package-Requires: ((emacs "24.3"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Hi! I found this package and found many warning/errors via package-lint.
I fix some warnings for my first contribution step.

### before
```emacs-lisp
 benchmark…     1   1 warning         Including "Emacs" in the package summary is usually redundant. (emacs-lisp-package)
 benchmark…     1   1 error           Package should have a Homepage or URL header. (emacs-lisp-package)
 benchmar…     9   4 warning         You should include standard keywords: see the variable `finder-known-keywords'. (emacs-lisp-package)
 benchmar…    58  11 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-lib'. (emacs-lisp-package)
 benchmar…    68   2 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-defstruct'. (emacs-lisp-package)
 benchmar…    78   1 error           `benchmark-init/durations-tree' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchmar…    85   1 error           `benchmark-init/current-node' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchmar…    90   1 error           `benchmark-init/time-subtract-millis' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…    94   1 error           `benchmark-init/flatten' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   108   1 error           `benchmark-init/node-root-p' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   112   1 error           `benchmark-init/node-duration-adjusted' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   120   1 error           `benchmark-init/sum-node-durations' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   129   1 error           `benchmark-init/begin-measure' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   138   1 error           `benchmark-init/end-measure' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   149   1 error           `benchmark-init/measure-around' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   177   1 error           `benchmark-init/deactivate' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   184   1 error           `benchmark-init/activate' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
```

### after
```emacs-lisp
 benchmar…    78   1 error           `benchmark-init/durations-tree' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchmar…    85   1 error           `benchmark-init/current-node' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchmar…    90   1 error           `benchmark-init/time-subtract-millis' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…    94   1 error           `benchmark-init/flatten' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   108   1 error           `benchmark-init/node-root-p' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   112   1 error           `benchmark-init/node-duration-adjusted' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   120   1 error           `benchmark-init/sum-node-durations' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   129   1 error           `benchmark-init/begin-measure' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   138   1 error           `benchmark-init/end-measure' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   149   1 error           `benchmark-init/measure-around' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   177   1 error           `benchmark-init/deactivate' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 benchma…   184   1 error           `benchmark-init/activate' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
```