### PR TITLE
Add version to define-obsolete-function-alias invocation

### DIFF
--- a/benchmark-init-modes.el
+++ b/benchmark-init-modes.el
@@ -209,7 +209,7 @@
 ;; Obsolete functions
 
 (define-obsolete-function-alias 'benchmark-init/show-durations
-  'benchmark-init/show-durations-tabulated)
+  'benchmark-init/show-durations-tabulated "1.0")
 
 (provide 'benchmark-init-modes)
 ;;; benchmark-init-modes.el ends here

--- a/benchmark-init-modes.el
+++ b/benchmark-init-modes.el
@@ -209,7 +209,7 @@
 ;; Obsolete functions
 
 (define-obsolete-function-alias 'benchmark-init/show-durations
-  'benchmark-init/show-durations-tabulated "1.0")
+  'benchmark-init/show-durations-tabulated "2014-04-05")
 
 (provide 'benchmark-init-modes)
 ;;; benchmark-init-modes.el ends here

--- a/benchmark-init.el
+++ b/benchmark-init.el
@@ -189,7 +189,7 @@ Slots:
 ;; Obsolete functions
 
 (define-obsolete-function-alias 'benchmark-init/install
-  'benchmark-init/activate)
+  'benchmark-init/activate "1.0")
 
 (provide 'benchmark-init)
 ;;; benchmark-init.el ends here

--- a/benchmark-init.el
+++ b/benchmark-init.el
@@ -189,7 +189,7 @@ Slots:
 ;; Obsolete functions
 
 (define-obsolete-function-alias 'benchmark-init/install
-  'benchmark-init/activate "1.0")
+  'benchmark-init/activate "2014-03-17")
 
 (provide 'benchmark-init)
 ;;; benchmark-init.el ends here


### PR DESCRIPTION
Emacs 28 requires this argument.
https://emba.gnu.org/emacs/emacs/-/commit/32c6732d16385f242b1109517f25e9aefd6caa5c