### PR TITLE
Allow lexical binding to fix issues with emacs 30

### DIFF
--- a/benchmark-init.el
+++ b/benchmark-init.el
@@ -1,4 +1,4 @@
-;;; benchmark-init.el --- Benchmarks for require and load calls
+;;; benchmark-init.el --- Benchmarks for require and load calls -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013 Steve Purcell
 ;; Copyright (C) 2013-2014 David Holm


### PR DESCRIPTION
Hi. In the latest Emacs 30 version, benchmark-init fails with the error: ```Symbol's function definition is void: (setf funcall)```.  

This issue seems to be caused by [this](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=64292 ):

I fixed it by allowing lexical-binding in the header.