### PR TITLE
Fixing "function might not be defined at runtime" errors.

### DIFF
--- a/benchmark-init-modes.el
+++ b/benchmark-init-modes.el
@@ -37,8 +37,7 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (require 'benchmark-init))
+(require 'benchmark-init)
 
 ;; Faces
 


### PR DESCRIPTION
Without this, I get the following errors when depending on this package:

Error: the function "benchmark-init/node-root-p" might not be defined at runtime.
Error: the function "benchmark-init/node-duration-adjusted" might not be defined at runtime.
Error: the function "benchmark-init/flatten" might not be defined at runtime.

This error is accurate as the eval-when-compile does not force the require during a normal load.