### PR TITLE
Ensuring mode line shows proper mode name when in tree mode.

### DIFF
--- a/benchmark-init-modes.el
+++ b/benchmark-init-modes.el
@@ -191,6 +191,7 @@
   (setq truncate-lines t)
   (use-local-map benchmark-init/tree-mode-map)
   (setq major-mode 'benchmark-init/tree-mode)
+  (setq mode-name "Benchmark Init Tree")
   (benchmark-init/tree-buffer-setup)
   (run-mode-hooks 'benchmark-init/tree-mode-hook))
 


### PR DESCRIPTION
Without this change, tree mode claims to be in Fundamental mode.