### PR TITLE
Small version bump changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version: [24.3, 24.4, 24.5, 25.1, 25.2, 25.3, 26.1, 26.2, 26.3,
-                        27.1, 27.2, 28.1, 28.2, 29.1]
+                        27.1, 27.2, 28.1, 28.2, 29.1, 29.2]
         # Due to this package not following proper namespace conventions (using
         # "/" instead of "--" for namespace separator), package-lint spits out a
         # bunch of errors.  So check everything else from the melpa check.

--- a/benchmark-init.el
+++ b/benchmark-init.el
@@ -7,7 +7,7 @@
 ;; Maintainer: David Holm <dholmster@gmail.com>
 ;; Created: 25 Apr 2013
 ;; Keywords: convenience benchmark
-;; Version: 1.1
+;; Version: 1.2
 ;; URL: https://github.com/dholm/benchmark-init-el
 ;; Package-Requires: ((emacs "24.3"))
 


### PR DESCRIPTION
This is a small cleanup. It adds automation for Emacs 29.2 (recently released) and also bumps the in-file declared version to 1.2.

I would appreciate if after this is merged a new tag `1.2` was added so [my package](https://github.com/chaosemer/init-dir) could properly depend on the newly merged functionality in #23. This way melpa-stable will pick up the new functionality.

Thanks!