### PR TITLE
Add backtrace reporting to detect autoload triggered calls

### DIFF
--- a/benchmark-init.el
+++ b/benchmark-init.el
@@ -9,7 +9,7 @@
 ;; Keywords: convenience benchmark
 ;; Version: 1.2
 ;; URL: https://github.com/dholm/benchmark-init-el
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Autoloading a library can not be detected via advice. Instead, record the function call sequence that resulted in a call to require or load. Because generating backtraces can be somewhat expensive, default to only generating backtraces for require calls.

This is somewhat more expensive than before because generating backtraces is expensive. If you would prefer, I can default to never generating backtraces in benchmark-init and instead pushing the backtrace generation to my init file.